### PR TITLE
make source package name singular

### DIFF
--- a/src/main/java/sc/fiji/bdv/BdvUtils.java
+++ b/src/main/java/sc/fiji/bdv/BdvUtils.java
@@ -1,6 +1,7 @@
 package sc.fiji.bdv;
 
 import bdv.VolatileSpimSource;
+import bdv.tools.brightness.MinMaxGroup;
 import bdv.tools.transformation.TransformedSource;
 import bdv.util.Bdv;
 import bdv.util.BdvHandle;

--- a/src/main/java/sc/fiji/bdv/BdvUtils.java
+++ b/src/main/java/sc/fiji/bdv/BdvUtils.java
@@ -152,7 +152,7 @@ public class BdvUtils {
 
 
     /**
-     * Returns the highest level where the sources voxel spacings are <= the requested ones.
+     * Returns the highest level where the source voxel spacings are <= the requested ones.
      *
      *
      * @param source

--- a/src/main/java/sc/fiji/bdv/screenshot/ScreenShotMaker.java
+++ b/src/main/java/sc/fiji/bdv/screenshot/ScreenShotMaker.java
@@ -181,9 +181,9 @@ public class ScreenShotMaker {
             /*
         RealRandomAccess< ? extends RealType< ? > > sourceAccess;
         if ( interpolate )
-            sourceAccess = getInterpolatedRealTypeNonVolatileRealRandomAccess( sources, t, level, Interpolation.NLINEAR );
+            sourceAccess = getInterpolatedRealTypeNonVolatileRealRandomAccess( source, t, level, Interpolation.NLINEAR );
         else
-            sourceAccess = getInterpolatedRealTypeNonVolatileRealRandomAccess( sources, t, level, Interpolation.NEARESTNEIGHBOR );
+            sourceAccess = getInterpolatedRealTypeNonVolatileRealRandomAccess( source, t, level, Interpolation.NEARESTNEIGHBOR );
 
         return sourceAccess;*/
     }

--- a/src/main/java/sc/fiji/bdv/source/add/AddSourceToBdv.java
+++ b/src/main/java/sc/fiji/bdv/source/add/AddSourceToBdv.java
@@ -1,4 +1,4 @@
-package sc.fiji.bdv.sources.add;
+package sc.fiji.bdv.source.add;
 
 import bdv.util.BdvFunctions;
 import bdv.util.BdvHandle;

--- a/src/main/java/sc/fiji/bdv/source/display/BrightnessAdjuster.java
+++ b/src/main/java/sc/fiji/bdv/source/display/BrightnessAdjuster.java
@@ -1,7 +1,6 @@
-package sc.fiji.bdv.sources.display;
+package sc.fiji.bdv.source.display;
 
 import bdv.tools.brightness.MinMaxGroup;
-import bdv.tools.brightness.SetupAssignments;
 import bdv.util.BdvHandle;
 import bdv.viewer.Source;
 import bdv.viewer.state.ViewerState;

--- a/src/main/java/sc/fiji/bdv/source/get/GetSourceByIndexFromBdv.java
+++ b/src/main/java/sc/fiji/bdv/source/get/GetSourceByIndexFromBdv.java
@@ -1,4 +1,4 @@
-package sc.fiji.bdv.sources.get;
+package sc.fiji.bdv.source.get;
 
 import bdv.util.BdvHandle;
 import bdv.viewer.Source;

--- a/src/main/java/sc/fiji/bdv/source/get/GetSourcesByIndexFromBdv.java
+++ b/src/main/java/sc/fiji/bdv/source/get/GetSourcesByIndexFromBdv.java
@@ -1,4 +1,4 @@
-package sc.fiji.bdv.sources.get;
+package sc.fiji.bdv.source.get;
 
 import bdv.util.BdvHandle;
 import bdv.viewer.Source;

--- a/src/main/java/sc/fiji/bdv/source/read/SourceAdder.java
+++ b/src/main/java/sc/fiji/bdv/source/read/SourceAdder.java
@@ -1,12 +1,10 @@
-package sc.fiji.bdv.sources.read;
+package sc.fiji.bdv.source.read;
 
 import bdv.util.BdvFunctions;
 import bdv.util.BdvHandle;
 import bdv.util.BdvOptions;
 import bdv.viewer.Source;
-import sc.fiji.bdv.BdvUtils;
 import sc.fiji.bdv.navigate.ViewerTransformAdjuster;
-import sc.fiji.bdv.sources.display.BrightnessAdjuster;
 
 public class SourceAdder implements Runnable
 {

--- a/src/main/java/sc/fiji/bdv/source/read/SourceLoader.java
+++ b/src/main/java/sc/fiji/bdv/source/read/SourceLoader.java
@@ -1,4 +1,4 @@
-package sc.fiji.bdv.sources.read;
+package sc.fiji.bdv.source.read;
 
 import bdv.BigDataViewer;
 import bdv.tools.brightness.ConverterSetup;

--- a/src/main/java/sc/fiji/bdv/source/read/SourcesLoaderAndAdder.java
+++ b/src/main/java/sc/fiji/bdv/source/read/SourcesLoaderAndAdder.java
@@ -1,15 +1,7 @@
-package sc.fiji.bdv.sources.read;
+package sc.fiji.bdv.source.read;
 
 import bdv.util.BdvHandle;
 import bdv.viewer.Source;
-import mpicbg.spim.data.SpimData;
-import sc.fiji.bdv.BDVSingleton;
-import sc.fiji.bdv.ClickBehaviourInstaller;
-import sc.fiji.bdv.MenuAdder;
-import sc.fiji.swing.MultipleFileSelector;
-
-import javax.swing.*;
-import java.io.File;
 
 public class SourcesLoaderAndAdder implements Runnable
 {

--- a/src/main/java/sc/fiji/bdv/source/read/ui/SourcesLoaderAndAdderCommand.java
+++ b/src/main/java/sc/fiji/bdv/source/read/ui/SourcesLoaderAndAdderCommand.java
@@ -1,4 +1,4 @@
-package sc.fiji.bdv.sources.read.ui;
+package sc.fiji.bdv.source.read.ui;
 
 import bdv.util.BdvHandle;
 import mpicbg.spim.data.SpimData;
@@ -8,10 +8,9 @@ import org.scijava.command.Command;
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
 import sc.fiji.bdv.BDVSingleton;
-import sc.fiji.bdv.BdvUtils;
 import sc.fiji.bdv.MenuAdder;
-import sc.fiji.bdv.sources.read.SourceLoader;
-import sc.fiji.bdv.sources.read.SourcesLoaderAndAdder;
+import sc.fiji.bdv.source.read.SourceLoader;
+import sc.fiji.bdv.source.read.SourcesLoaderAndAdder;
 import sc.fiji.util.Util;
 
 import java.io.File;

--- a/src/main/java/sc/fiji/bdv/source/read/ui/SourcesLoaderAndAdderSwingDialog.java
+++ b/src/main/java/sc/fiji/bdv/source/read/ui/SourcesLoaderAndAdderSwingDialog.java
@@ -1,10 +1,10 @@
-package sc.fiji.bdv.sources.read.ui;
+package sc.fiji.bdv.source.read.ui;
 
 import bdv.util.BdvHandle;
 import sc.fiji.bdv.BDVSingleton;
 import sc.fiji.bdv.ClickBehaviourInstaller;
 import sc.fiji.bdv.MenuAdder;
-import sc.fiji.bdv.sources.read.SourcesLoaderAndAdder;
+import sc.fiji.bdv.source.read.SourcesLoaderAndAdder;
 import sc.fiji.swing.MultipleFileSelector;
 
 import javax.swing.*;

--- a/src/main/java/sc/fiji/bdv/source/transform/SourceAffineTransform.java
+++ b/src/main/java/sc/fiji/bdv/source/transform/SourceAffineTransform.java
@@ -1,8 +1,8 @@
-package sc.fiji.bdv.sources.transform;
+package sc.fiji.bdv.source.transform;
 
+import bdv.tools.transformation.TransformedSource;
 import bdv.viewer.Source;
-import bdv.img.WarpedSource;
-import net.imglib2.realtransform.RealTransform;
+import net.imglib2.realtransform.AffineTransform3D;
 
 import java.util.function.Function;
 
@@ -12,20 +12,20 @@ import java.util.function.Function;
 // Another information : the transform is duplicated during the call to setFixedTransform ->
 // Transform not passed by reference
 
-public class SourceRealTransform implements Runnable, Function<Source,Source> {
+public class SourceAffineTransform implements Runnable, Function<Source, Source> {
 
     Source sourceIn;
-    RealTransform rt;
-    WarpedSource sourceOut;
+    AffineTransform3D at3D;
+    TransformedSource sourceOut;
 
-    public SourceRealTransform(Source src, RealTransform rt) {
+    public SourceAffineTransform(Source src, AffineTransform3D at3D) {
         this.sourceIn = src;
-        this.rt = rt;
+        this.at3D = at3D;
     }
 
     @Override
     public void run() {
-        sourceOut = (WarpedSource) apply(sourceIn);
+       sourceOut = (TransformedSource) apply(sourceIn);
     }
 
     public Source getSourceOut() {
@@ -33,9 +33,8 @@ public class SourceRealTransform implements Runnable, Function<Source,Source> {
     }
 
     public Source apply(Source in) {
-        WarpedSource out = new WarpedSource(in, "Transformed_"+in.getName());
-        out.updateTransform(rt);
-        out.setIsTransformed(true);
+        TransformedSource out = new TransformedSource(in);
+        out.setFixedTransform(at3D);
         return out;
     }
 }

--- a/src/main/java/sc/fiji/bdv/source/transform/SourceRealTransform.java
+++ b/src/main/java/sc/fiji/bdv/source/transform/SourceRealTransform.java
@@ -1,8 +1,8 @@
-package sc.fiji.bdv.sources.transform;
+package sc.fiji.bdv.source.transform;
 
-import bdv.tools.transformation.TransformedSource;
 import bdv.viewer.Source;
-import net.imglib2.realtransform.AffineTransform3D;
+import bdv.img.WarpedSource;
+import net.imglib2.realtransform.RealTransform;
 
 import java.util.function.Function;
 
@@ -12,20 +12,20 @@ import java.util.function.Function;
 // Another information : the transform is duplicated during the call to setFixedTransform ->
 // Transform not passed by reference
 
-public class SourceAffineTransform implements Runnable, Function<Source, Source> {
+public class SourceRealTransform implements Runnable, Function<Source,Source> {
 
     Source sourceIn;
-    AffineTransform3D at3D;
-    TransformedSource sourceOut;
+    RealTransform rt;
+    WarpedSource sourceOut;
 
-    public SourceAffineTransform(Source src, AffineTransform3D at3D) {
+    public SourceRealTransform(Source src, RealTransform rt) {
         this.sourceIn = src;
-        this.at3D = at3D;
+        this.rt = rt;
     }
 
     @Override
     public void run() {
-       sourceOut = (TransformedSource) apply(sourceIn);
+        sourceOut = (WarpedSource) apply(sourceIn);
     }
 
     public Source getSourceOut() {
@@ -33,8 +33,9 @@ public class SourceAffineTransform implements Runnable, Function<Source, Source>
     }
 
     public Source apply(Source in) {
-        TransformedSource out = new TransformedSource(in);
-        out.setFixedTransform(at3D);
+        WarpedSource out = new WarpedSource(in, "Transformed_"+in.getName());
+        out.updateTransform(rt);
+        out.setIsTransformed(true);
         return out;
     }
 }

--- a/src/test/src/sc/fiji/bdv/navigate/ViewerTransformAdjusterDemo.java
+++ b/src/test/src/sc/fiji/bdv/navigate/ViewerTransformAdjusterDemo.java
@@ -1,22 +1,8 @@
 package sc.fiji.bdv.navigate;
 
-import bdv.util.BdvFunctions;
 import bdv.util.BdvHandle;
-import ij.IJ;
-import ij.ImageJ;
-import ij.ImagePlus;
-import mpicbg.spim.data.SpimData;
-import mpicbg.spim.data.SpimDataException;
-import mpicbg.spim.data.XmlIoSpimData;
-import net.imglib2.RandomAccessibleInterval;
-import net.imglib2.img.display.imagej.ImageJFunctions;
-import net.imglib2.realtransform.AffineTransform3D;
 import sc.fiji.bdv.BDVSingleton;
-import sc.fiji.bdv.ClickBehaviourInstaller;
-import sc.fiji.bdv.screenshot.ScreenShotMaker;
-import sc.fiji.bdv.sources.read.SourceAdder;
-import sc.fiji.bdv.sources.read.SourceLoader;
-import sc.fiji.bdv.sources.read.SourcesLoaderAndAdder;
+import sc.fiji.bdv.source.read.SourcesLoaderAndAdder;
 
 /**
  * ViewerTransformAdjusterDemo

--- a/src/test/src/sc/fiji/bdv/sourceAndConverter/AffineTransformSourceAndConverterBatchDemo.java
+++ b/src/test/src/sc/fiji/bdv/sourceAndConverter/AffineTransformSourceAndConverterBatchDemo.java
@@ -9,10 +9,10 @@ import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.img.display.imagej.ImageJFunctions;
 import net.imglib2.realtransform.AffineTransform3D;
 import sc.fiji.bdv.BDVSingleton;
-import sc.fiji.bdv.sources.add.AddSourceToBdv;
-import sc.fiji.bdv.sources.get.GetSourceByIndexFromBdv;
-import sc.fiji.bdv.sources.get.GetSourcesByIndexFromBdv;
-import sc.fiji.bdv.sources.transform.SourceAffineTransform;
+import sc.fiji.bdv.source.add.AddSourceToBdv;
+import sc.fiji.bdv.source.get.GetSourceByIndexFromBdv;
+import sc.fiji.bdv.source.get.GetSourcesByIndexFromBdv;
+import sc.fiji.bdv.source.transform.SourceAffineTransform;
 
 import java.util.List;
 
@@ -43,13 +43,13 @@ public class AffineTransformSourceAndConverterBatchDemo {
 
         // Construct source getter based on their indexes and on a BdvHandle
         GetSourcesByIndexFromBdv srcGetter = new GetSourcesByIndexFromBdv(bdvHandle, 2,4,6,8,10,12);
-        // Actually get the sources
+        // Actually get the source
         srcGetter.run();
 
-        // Transform all the sources, using the affineTransformer
+        // Transform all the source, using the affineTransformer
         List<Source> transformedSources = Lists.transform(srcGetter.getSources(), affineTransformer::apply);
 
-        // Display all the transformed sources, using the bdvAdder
+        // Display all the transformed source, using the bdvAdder
         transformedSources.forEach(bdvAdder::accept);
 
     }

--- a/src/test/src/sc/fiji/bdv/sourceAndConverter/AffineTransformSourceAndConverterDemo.java
+++ b/src/test/src/sc/fiji/bdv/sourceAndConverter/AffineTransformSourceAndConverterDemo.java
@@ -7,10 +7,10 @@ import bdv.viewer.Source;
 import mpicbg.spim.data.SpimData;
 import net.imglib2.realtransform.AffineTransform3D;
 import sc.fiji.bdv.BDVSingleton;
-import sc.fiji.bdv.sources.add.AddSourceToBdv;
-import sc.fiji.bdv.sources.get.GetSourceByIndexFromBdv;
-import sc.fiji.bdv.sources.read.SourceLoader;
-import sc.fiji.bdv.sources.transform.SourceAffineTransform;
+import sc.fiji.bdv.source.add.AddSourceToBdv;
+import sc.fiji.bdv.source.get.GetSourceByIndexFromBdv;
+import sc.fiji.bdv.source.read.SourceLoader;
+import sc.fiji.bdv.source.transform.SourceAffineTransform;
 
 public class AffineTransformSourceAndConverterDemo {
 


### PR DESCRIPTION
I have the feeling this is more consistent with our other package names.

`sources.*` -> `source.*`