### PR TITLE
Add a ZSlider in bdv based on ray casting

### DIFF
--- a/src/main/java/sc/fiji/bdvpg/bdv/BdvHandleHelper.java
+++ b/src/main/java/sc/fiji/bdvpg/bdv/BdvHandleHelper.java
@@ -29,10 +29,14 @@
 package sc.fiji.bdvpg.bdv;
 
 import bdv.tools.brightness.ConverterSetup;
+import bdv.util.BdvFunctions;
 import bdv.util.BdvHandle;
+import bdv.util.BdvOptions;
+import bdv.util.BdvOverlay;
 import bdv.viewer.Source;
 import net.imglib2.*;
 import net.imglib2.realtransform.AffineTransform3D;
+import net.imglib2.type.numeric.ARGBType;
 import net.imglib2.util.Intervals;
 import net.imglib2.util.LinAlgHelpers;
 import org.scijava.cache.CacheService;
@@ -46,6 +50,7 @@ import sc.fiji.bdvpg.bdv.config.BdvSettingsGUISetter;
 import sc.fiji.bdvpg.scijava.services.SourceAndConverterBdvDisplayService;
 
 import javax.swing.*;
+import java.awt.*;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 import java.io.File;
@@ -433,6 +438,29 @@ public class BdvHandleHelper
             // TODO : support replacement of key bindings bdv.getKeybindings().addInputMap("bdvpg", new InputMap(), "bdv", "navigation");
         }
 
+    }
+
+
+    public static BdvOverlay addCenterCross(BdvHandle bdvh) {
+        final BdvOverlay overlay = new BdvOverlay()
+        {
+            @Override
+            protected void draw( final Graphics2D g )
+            {
+                int colorCode = this.info.getColor().get();
+                int w = bdvh.getViewerPanel().getWidth();
+                int h = bdvh.getViewerPanel().getHeight();
+                g.setColor(new Color(ARGBType.red(colorCode) , ARGBType.green(colorCode), ARGBType.blue(colorCode), ARGBType.alpha(colorCode) ));
+                g.drawLine(w/2, h/2-h/4,w/2, h/2+h/4 );
+                g.drawLine(w/2-w/4, h/2,w/2+w/4, h/2 );
+            }
+
+        };
+
+        int nTimepoints = bdvh.getViewerPanel().state().getNumTimepoints();
+        BdvFunctions.showOverlay( overlay, "cross_overlay", BdvOptions.options().addTo( bdvh ) );
+        bdvh.getViewerPanel().setTimepoint(nTimepoints);
+        return overlay;
     }
 
 }

--- a/src/main/java/sc/fiji/bdvpg/bdv/navigate/RayCastPositionerSliderAdder.java
+++ b/src/main/java/sc/fiji/bdvpg/bdv/navigate/RayCastPositionerSliderAdder.java
@@ -1,0 +1,156 @@
+package sc.fiji.bdvpg.bdv.navigate;
+
+import bdv.util.BdvHandle;
+import bdv.viewer.SourceAndConverter;
+import bdv.viewer.TimePointListener;
+import bdv.viewer.TransformListener;
+import bdv.viewer.ViewerStateChangeListener;
+import net.imglib2.RealPoint;
+import net.imglib2.realtransform.AffineTransform3D;
+import sc.fiji.bdvpg.bdv.BdvHandleHelper;
+import sc.fiji.bdvpg.sourceandconverter.SourceAndConverterHelper;
+
+import javax.swing.*;
+import java.awt.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Adds a Z slider for BigDataViewer windows. It works by casting a ray at the middle
+ * of the bdv window and finding all intersecting planes.
+ *
+ * The slider updates itself to the current plane when the user moves in a 'regular'
+ * way the bdv window. The slider can be moved by the user in order to update the viewer
+ * to a different plane.
+ *
+ * @author Nicolas Chiaruttini, EPFL, 2021
+ *
+ */
+public class RayCastPositionerSliderAdder implements Runnable {
+
+    final BdvHandle bdvh;
+
+    private List<Double> zLocations  = new ArrayList<>();
+
+    final JSlider slider;
+
+    public RayCastPositionerSliderAdder(BdvHandle bdvh) {
+        this.bdvh = bdvh;
+        slider = new JSlider(JSlider.VERTICAL);
+    }
+
+    int nPositions;
+    int currentPosition;
+    RealPoint lastDirection = new RealPoint();
+
+    synchronized void setPositions(List<Double> zLocations) {
+        //if (zLocations.size()>0) {
+            this.zLocations = new ArrayList<>(zLocations);
+            if (nPositions != zLocations.size()) {
+                // Change of number of planes
+                nPositions = zLocations.size();
+                slider.setMaximum(nPositions - 1);
+            }
+            int i = 0;
+            while ((i < nPositions) && (this.zLocations.get(i) < 0)) i++;
+            if (currentPosition != i) {
+                currentPosition = i;
+                slider.setValue(i);
+            }
+        //}
+    }
+
+    final TransformListener<AffineTransform3D> transformListener = (transform) -> updatePositions();
+    final ViewerStateChangeListener changeListener = (viewerStateChange) -> updatePositions();
+    final TimePointListener timePointListener = (timepoint) -> updatePositions();
+
+    @Override
+    public void run() {
+
+        bdvh.getViewerPanel().addTransformListener(transformListener);
+        bdvh.getViewerPanel().addTimePointListener(timePointListener);
+        bdvh.getViewerPanel().state().changeListeners().add(changeListener);
+        bdvh.getViewerPanel().add(slider, BorderLayout.WEST);
+        bdvh.getViewerPanel().revalidate();
+
+        slider.addChangeListener((e) -> {
+            if (zLocations.size()>0) {
+                JSlider slider = (JSlider) e.getSource();
+                int newValue = slider.getValue();
+                //Plane : slider.getValue() / slider.getMaximum()
+                if ((currentPosition != newValue)&&(newValue!=-1)) {
+                    //User slider action: needs update of viewer from currentPosition to newValue
+                    currentPosition = newValue;
+                    double shiftZ = zLocations.get(currentPosition);
+                    //Need to shift z by shiftZ
+
+                    AffineTransform3D at3d = new AffineTransform3D();
+
+                    // Change the position of the viewer with the new offset
+                    bdvh.getViewerPanel().state().getViewerTransform(at3d);
+                    double[] currentCenter = BdvHandleHelper.getWindowCentreInCalibratedUnits(bdvh);
+                    double[] newCenter = new double[3];
+                    newCenter[0] = currentCenter[0]+lastDirection.getDoublePosition(0) * shiftZ;
+                    newCenter[1] = currentCenter[1]+lastDirection.getDoublePosition(1) * shiftZ;
+                    newCenter[2] = currentCenter[2]+lastDirection.getDoublePosition(2) * shiftZ;
+                    bdvh.getViewerPanel().state().setViewerTransform(BdvHandleHelper.getViewerTransformWithNewCenter(bdvh, newCenter));
+
+                } // else: Bdv user movement: no update required
+
+            }
+        });
+
+    }
+
+    public void updatePositions() {
+
+        // Find origin and direction of ray - center of the bdv window
+        double[] c = BdvHandleHelper.getWindowCentreInCalibratedUnits(bdvh);
+        RealPoint origin = new RealPoint(3);
+        origin.setPosition(c[0],0);
+        origin.setPosition(c[1],1);
+        origin.setPosition(c[2],2);
+
+        RealPoint direction = new RealPoint(0,0,1);
+        final AffineTransform3D affineTransform3D = new AffineTransform3D();
+        bdvh.getViewerPanel().state().getViewerTransform( affineTransform3D );
+        affineTransform3D.setTranslation(0,0,0);
+        affineTransform3D.inverse().apply(direction,direction);
+        SourceAndConverterHelper.normalize3(direction);
+
+        lastDirection = new RealPoint(direction);
+
+        // Initializes zLocations : empty
+        List<Double> zLocations = new ArrayList<>();
+        int timepoint = bdvh.getViewerPanel().state().getCurrentTimepoint();
+
+        for (SourceAndConverter<?> source : bdvh.getViewerPanel().state().getActiveSources()) {
+            zLocations.addAll(SourceAndConverterHelper.rayIntersect(source,timepoint,origin, direction));
+        }
+
+        // Precision loss for efficient duplicates removal
+        zLocations = zLocations.stream().map(d -> (double) (d.floatValue())).collect(Collectors.toList());
+
+        // Fast
+        zLocations = zLocations
+                .stream()
+                .sorted()
+                .distinct() // Removes duplicate z positions
+                .collect(Collectors.toList());
+
+        setPositions(zLocations);
+    }
+
+    public BdvHandle getBdvh() {
+        return bdvh;
+    }
+
+    public void removeFromBdv() {
+        bdvh.getViewerPanel().removeTransformListener(transformListener);
+        bdvh.getViewerPanel().removeTimePointListener(timePointListener);
+        bdvh.getViewerPanel().state().changeListeners().remove(changeListener);
+        bdvh.getViewerPanel().remove(slider);
+        bdvh.getViewerPanel().revalidate();
+    }
+}

--- a/src/main/java/sc/fiji/bdvpg/behaviour/EditorBehaviourInstaller.java
+++ b/src/main/java/sc/fiji/bdvpg/behaviour/EditorBehaviourInstaller.java
@@ -32,7 +32,6 @@ import bdv.util.BdvHandle;
 import ch.epfl.biop.bdv.select.SourceSelectorBehaviour;
 import ch.epfl.biop.bdv.select.ToggleListener;
 import com.google.gson.Gson;
-import net.imglib2.realtransform.ThinPlateSplineTransformAdapter;
 import org.scijava.ui.behaviour.ClickBehaviour;
 import org.scijava.ui.behaviour.io.InputTriggerConfig;
 import org.scijava.ui.behaviour.util.Behaviours;
@@ -76,7 +75,7 @@ public class EditorBehaviourInstaller implements Runnable {
                 "Inspect Sources",
                 "PopupLine",
                 getCommandName(SourcesInvisibleMakerCommand.class),
-                getCommandName(BrightnessAdjusterCommand.class),
+                getCommandName(InteractiveBrightnessAdjusterCommand.class),
                 getCommandName(SourceColorChangerCommand.class),
                 "PopupLine",
                 getCommandName(SourcesRemoverCommand.class)};

--- a/src/main/java/sc/fiji/bdvpg/scijava/command/bdv/BdvOrthoWindowCreatorCommand.java
+++ b/src/main/java/sc/fiji/bdvpg/scijava/command/bdv/BdvOrthoWindowCreatorCommand.java
@@ -29,7 +29,6 @@
 package sc.fiji.bdvpg.scijava.command.bdv;
 
 import bdv.util.*;
-import bdv.viewer.render.AccumulateProjectorFactory;
 import net.imglib2.type.numeric.ARGBType;
 import org.scijava.ItemIO;
 import org.scijava.plugin.Parameter;
@@ -101,9 +100,9 @@ public class BdvOrthoWindowCreatorCommand implements BdvPlaygroundActionCommand 
         new ViewerOrthoSyncStarter(bdvhx, bdvhz, bdvhy, synctime).run();
 
        if (drawcrosses) {
-           addCross(bdvhx);
-           addCross(bdvhy);
-           addCross(bdvhz);
+           BdvHandleHelper.addCenterCross(bdvhx);
+           BdvHandleHelper.addCenterCross(bdvhy);
+           BdvHandleHelper.addCenterCross(bdvhz);
        }
     }
 
@@ -124,26 +123,6 @@ public class BdvOrthoWindowCreatorCommand implements BdvPlaygroundActionCommand 
         }
 
         return bdvh;
-    }
-
-    void addCross(BdvHandle bdvh) {
-        final BdvOverlay overlay = new BdvOverlay()
-        {
-            @Override
-            protected void draw( final Graphics2D g )
-            {
-                int colorCode = this.info.getColor().get();
-                int w = bdvh.getViewerPanel().getWidth();
-                int h = bdvh.getViewerPanel().getHeight();
-                g.setColor(new Color(ARGBType.red(colorCode) , ARGBType.green(colorCode), ARGBType.blue(colorCode), ARGBType.alpha(colorCode) ));
-                g.drawLine(w/2, h/2-h/4,w/2, h/2+h/4 );
-                g.drawLine(w/2-w/4, h/2,w/2+w/4, h/2 );
-            }
-
-        };
-
-        BdvFunctions.showOverlay( overlay, "cross_overlay", BdvOptions.options().addTo( bdvh ) );
-        bdvh.getViewerPanel().setTimepoint(ntimepoints);
     }
 
 }

--- a/src/main/java/sc/fiji/bdvpg/scijava/command/bdv/BdvSelectCommand.java
+++ b/src/main/java/sc/fiji/bdvpg/scijava/command/bdv/BdvSelectCommand.java
@@ -26,41 +26,25 @@
  * POSSIBILITY OF SUCH DAMAGE.
  * #L%
  */
-package sc.fiji.bdvpg.scijava.command.source;
+package sc.fiji.bdvpg.scijava.command.bdv;
 
-import bdv.viewer.SourceAndConverter;
-import org.scijava.command.InteractiveCommand;
+import bdv.util.BdvHandle;
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
+import sc.fiji.bdvpg.bdv.BdvHandleHelper;
 import sc.fiji.bdvpg.scijava.ScijavaBdvDefaults;
 import sc.fiji.bdvpg.scijava.command.BdvPlaygroundActionCommand;
-import sc.fiji.bdvpg.services.SourceAndConverterServices;
-import sc.fiji.bdvpg.sourceandconverter.display.BrightnessAdjuster;
 
-import java.text.DecimalFormat;
+@Plugin(type = BdvPlaygroundActionCommand.class, menuPath = ScijavaBdvDefaults.RootMenu+"BDV>BDV - Select Window",
+    description = "Select a BDV Windows")
 
-import static org.scijava.ItemVisibility.MESSAGE;
+public class BdvSelectCommand implements BdvPlaygroundActionCommand {
 
-/**
- *
- * @author Nicolas Chiaruttini, EPFL 2020
- */
-
-@Plugin(type = BdvPlaygroundActionCommand.class,  menuPath = ScijavaBdvDefaults.RootMenu+"Sources>Display>Set Sources Brightness")
-public class BrightnessAdjusterCommand implements BdvPlaygroundActionCommand {
-
-    @Parameter(label = "Select Source(s)")
-    SourceAndConverter[] sacs;
-
-    @Parameter()
-    double min;
-
-    @Parameter()
-    double max;
+    @Parameter(label = "Select BDV Window")
+    BdvHandle bdvh;
 
     public void run() {
-        for (SourceAndConverter source:sacs) {
-            new BrightnessAdjuster(source, min, max).run();
-        }
+        BdvHandleHelper.activateWindow(bdvh);
     }
+
 }

--- a/src/main/java/sc/fiji/bdvpg/scijava/command/bdv/BdvSetTitleCommand.java
+++ b/src/main/java/sc/fiji/bdvpg/scijava/command/bdv/BdvSetTitleCommand.java
@@ -26,41 +26,28 @@
  * POSSIBILITY OF SUCH DAMAGE.
  * #L%
  */
-package sc.fiji.bdvpg.scijava.command.source;
+package sc.fiji.bdvpg.scijava.command.bdv;
 
-import bdv.viewer.SourceAndConverter;
-import org.scijava.command.InteractiveCommand;
+import bdv.util.BdvHandle;
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
+import sc.fiji.bdvpg.bdv.BdvHandleHelper;
 import sc.fiji.bdvpg.scijava.ScijavaBdvDefaults;
 import sc.fiji.bdvpg.scijava.command.BdvPlaygroundActionCommand;
-import sc.fiji.bdvpg.services.SourceAndConverterServices;
-import sc.fiji.bdvpg.sourceandconverter.display.BrightnessAdjuster;
 
-import java.text.DecimalFormat;
+@Plugin(type = BdvPlaygroundActionCommand.class, menuPath = ScijavaBdvDefaults.RootMenu+"BDV>BDV - Set Title",
+    description = "Sets the title of a BDV Windows")
 
-import static org.scijava.ItemVisibility.MESSAGE;
+public class BdvSetTitleCommand implements BdvPlaygroundActionCommand {
 
-/**
- *
- * @author Nicolas Chiaruttini, EPFL 2020
- */
+    @Parameter(label = "Select BDV Window")
+    BdvHandle bdvh;
 
-@Plugin(type = BdvPlaygroundActionCommand.class,  menuPath = ScijavaBdvDefaults.RootMenu+"Sources>Display>Set Sources Brightness")
-public class BrightnessAdjusterCommand implements BdvPlaygroundActionCommand {
-
-    @Parameter(label = "Select Source(s)")
-    SourceAndConverter[] sacs;
-
-    @Parameter()
-    double min;
-
-    @Parameter()
-    double max;
+    @Parameter(label = "title")
+    String title;
 
     public void run() {
-        for (SourceAndConverter source:sacs) {
-            new BrightnessAdjuster(source, min, max).run();
-        }
+        BdvHandleHelper.setWindowTitle(bdvh, title);
     }
+
 }

--- a/src/main/java/sc/fiji/bdvpg/scijava/command/source/BasicTransformerCommand.java
+++ b/src/main/java/sc/fiji/bdvpg/scijava/command/source/BasicTransformerCommand.java
@@ -63,8 +63,11 @@ public class BasicTransformerCommand implements BdvPlaygroundActionCommand {
     @Parameter(choices = {"X", "Y", "Z"})
     String axis;
 
-    @Parameter
-    int timepoint;
+    @Parameter(label = "Initial timepoint (0 based)")
+    int initimepoint;
+
+    @Parameter(label = "Number of timepoints (min 1)", min = "1")
+    int ntimepoints;
 
     @Parameter(label = "Global transform (relative to the origin of the world)")
     boolean globalchange;
@@ -87,46 +90,47 @@ public class BasicTransformerCommand implements BdvPlaygroundActionCommand {
                 }
                 if (globalchange) {
                     if (sac.getSpimSource() instanceof TransformedSource) {
-                        SourceTransformHelper.mutate(at3D_global, new SourceAndConverterAndTimeRange(sac, timepoint));
+                        SourceTransformHelper.mutate(at3D_global, new SourceAndConverterAndTimeRange(sac, initimepoint, initimepoint+ntimepoints));
                     } else {
-                        SourceTransformHelper.append(at3D_global, new SourceAndConverterAndTimeRange(sac, timepoint));
+                        SourceTransformHelper.append(at3D_global, new SourceAndConverterAndTimeRange(sac, initimepoint, initimepoint+ntimepoints));
                     }
                 } else {
-                    // Maintain center of box constant
-                    AffineTransform3D at3D = new AffineTransform3D();
-                    at3D.identity();
-                    //double[] m = at3D.getRowPackedCopy();
-                    sac.getSpimSource().getSourceTransform(timepoint,0,at3D);
-                    long[] dims = new long[3];
-                    sac.getSpimSource().getSource(timepoint,0).dimensions(dims);
+                    for (int timepoint = initimepoint; timepoint< initimepoint+ntimepoints; timepoint++){
+                        // Maintain center of box constant
+                        AffineTransform3D at3D = new AffineTransform3D();
+                        at3D.identity();
+                        //double[] m = at3D.getRowPackedCopy();
+                        sac.getSpimSource().getSourceTransform(timepoint, 0, at3D);
+                        long[] dims = new long[3];
+                        sac.getSpimSource().getSource(timepoint, 0).dimensions(dims);
 
-                    RealPoint ptCenterGlobalBefore = new RealPoint(3);
-                    RealPoint ptCenterPixel = new RealPoint((dims[0]-1.0)/2.0,(dims[1]-1.0)/2.0, (dims[2]-1.0)/2.0);
+                        RealPoint ptCenterGlobalBefore = new RealPoint(3);
+                        RealPoint ptCenterPixel = new RealPoint((dims[0] - 1.0) / 2.0, (dims[1] - 1.0) / 2.0, (dims[2] - 1.0) / 2.0);
 
-                    at3D.apply(ptCenterPixel, ptCenterGlobalBefore);
+                        at3D.apply(ptCenterPixel, ptCenterGlobalBefore);
 
-                    RealPoint ptCenterGlobalAfter = new RealPoint(3);
+                        RealPoint ptCenterGlobalAfter = new RealPoint(3);
 
-                    at3D_global.apply(ptCenterGlobalBefore, ptCenterGlobalAfter);
+                        at3D_global.apply(ptCenterGlobalBefore, ptCenterGlobalAfter);
 
-                    // Just shifting
-                    double[] m = at3D_global.getRowPackedCopy();
+                        // Just shifting
+                        double[] m = at3D_global.getRowPackedCopy();
 
-                    m[3] -= ptCenterGlobalAfter.getDoublePosition(0)-ptCenterGlobalBefore.getDoublePosition(0);
+                        m[3] -= ptCenterGlobalAfter.getDoublePosition(0) - ptCenterGlobalBefore.getDoublePosition(0);
 
-                    m[7] -= ptCenterGlobalAfter.getDoublePosition(1)-ptCenterGlobalBefore.getDoublePosition(1);
+                        m[7] -= ptCenterGlobalAfter.getDoublePosition(1) - ptCenterGlobalBefore.getDoublePosition(1);
 
-                    m[11] -= ptCenterGlobalAfter.getDoublePosition(2)-ptCenterGlobalBefore.getDoublePosition(2);
+                        m[11] -= ptCenterGlobalAfter.getDoublePosition(2) - ptCenterGlobalBefore.getDoublePosition(2);
 
-                    at3D_global.set(m);
+                        at3D_global.set(m);
 
-                    if (sac.getSpimSource() instanceof TransformedSource) {
-                        SourceTransformHelper.mutate(at3D_global, new SourceAndConverterAndTimeRange(sac, timepoint));
-                    } else {
-                        SourceTransformHelper.append(at3D_global, new SourceAndConverterAndTimeRange(sac, timepoint));
+                        if (sac.getSpimSource() instanceof TransformedSource) {
+                            SourceTransformHelper.mutate(at3D_global, new SourceAndConverterAndTimeRange(sac, timepoint));
+                        } else {
+                            SourceTransformHelper.append(at3D_global, new SourceAndConverterAndTimeRange(sac, timepoint));
+                        }
+                        //SourceTransformHelper.append(at3D_global, new SourceAndConverterAndTimeRange(sac, timepoint));
                     }
-                    //SourceTransformHelper.append(at3D_global, new SourceAndConverterAndTimeRange(sac, timepoint));
-
                 }
             }
         }

--- a/src/main/java/sc/fiji/bdvpg/scijava/command/source/InteractiveBrightnessAdjusterCommand.java
+++ b/src/main/java/sc/fiji/bdvpg/scijava/command/source/InteractiveBrightnessAdjusterCommand.java
@@ -1,0 +1,129 @@
+/*-
+ * #%L
+ * BigDataViewer-Playground
+ * %%
+ * Copyright (C) 2019 - 2021 Nicolas Chiaruttini, EPFL - Robert Haase, MPI CBG - Christian Tischer, EMBL
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package sc.fiji.bdvpg.scijava.command.source;
+
+import bdv.viewer.SourceAndConverter;
+import org.scijava.command.InteractiveCommand;
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+import sc.fiji.bdvpg.scijava.ScijavaBdvDefaults;
+import sc.fiji.bdvpg.scijava.command.BdvPlaygroundActionCommand;
+import sc.fiji.bdvpg.services.SourceAndConverterServices;
+import sc.fiji.bdvpg.sourceandconverter.display.BrightnessAdjuster;
+
+import java.text.DecimalFormat;
+
+import static org.scijava.ItemVisibility.MESSAGE;
+
+/**
+ *
+ * @author Nicolas Chiaruttini, EPFL 2020
+ */
+
+@Plugin(type = BdvPlaygroundActionCommand.class, initializer = "init",  menuPath = ScijavaBdvDefaults.RootMenu+"Sources>Display>Set Sources Brightness (Interactive)")
+public class InteractiveBrightnessAdjusterCommand extends InteractiveCommand implements BdvPlaygroundActionCommand {
+
+    @Parameter(label = "Sources :", required = false, description = "Label the sources controlled by this window", persist = false)
+    String customsourcelabel = "Label your sources here";
+
+    @Parameter(label = "Select Source(s)")
+    SourceAndConverter[] sacs;
+
+    @Parameter(visibility=MESSAGE, required=false, style = "text field")
+    String message = "Display Range [ NaN - NaN ]";
+
+    @Parameter(callback = "updateMessage")
+    double min;
+
+    @Parameter(callback = "updateMessage")
+    double max;
+
+    @Parameter(label = "relative Minimum", style = "slider", min = "0", max = "1000", callback = "updateMessage")
+    double minslider;
+
+    @Parameter(label = "relative Maximum", style = "slider", min = "0", max = "1000", callback = "updateMessage")
+    double maxslider;
+
+    boolean firstTimeCalled = true;
+
+    boolean secondTimeCalled = true;
+
+    public void run() {
+        if ((!firstTimeCalled)&&(!secondTimeCalled)) {
+            double minValue = min + minslider /1000.0*(max-min);
+            double maxValue = min + maxslider /1000.0*(max-min);
+            for (SourceAndConverter source:sacs) {
+                new BrightnessAdjuster(source, minValue, maxValue).run();
+            }
+        } else {
+            init();
+            if (firstTimeCalled) {
+                firstTimeCalled = false;
+            } else if (secondTimeCalled) {
+                secondTimeCalled = false;
+            }
+        }
+    }
+
+    DecimalFormat formatter = new DecimalFormat("#.###");
+
+    public void updateMessage() {
+        formatter.setMinimumFractionDigits(3);
+        double minValue = min + minslider /1000.0*(max-min);
+        double maxValue = min + maxslider /1000.0*(max-min);
+        message = "Display Range ["+ formatter.format(minValue) +" - "+ formatter.format(maxValue) +"]";
+    }
+
+
+    public void init() {
+        if (sacs!=null)
+        if (sacs.length>0) {
+            double minSource = SourceAndConverterServices.getBdvDisplayService().getConverterSetup(sacs[0]).getDisplayRangeMin();
+            double maxSource = SourceAndConverterServices.getBdvDisplayService().getConverterSetup(sacs[0]).getDisplayRangeMax();
+
+            if (minSource>=0) {
+                min = 0;
+            } else {
+                min = minSource;
+            }
+            if (maxSource>65535) {
+                max = maxSource;
+            } else if (maxSource>255) {
+                max = 65535;
+            } else if (maxSource>1){
+                max = 255;
+            } else {
+                max = 1;
+            }
+            minslider = (minSource-min)/(max-min)*1000;
+            maxslider = (maxSource-min)/(max-min)*1000;
+            message = "Display Range [ NaN - NaN ]";
+        }
+    }
+}

--- a/src/main/java/sc/fiji/bdvpg/scijava/converters/StringToSourceAndConverterArray.java
+++ b/src/main/java/sc/fiji/bdvpg/scijava/converters/StringToSourceAndConverterArray.java
@@ -36,6 +36,7 @@ import sc.fiji.bdvpg.scijava.services.SourceAndConverterService;
 
 import javax.swing.tree.TreePath;
 
+
 /**
  * TODO : allows multiple Paths splitted by a character ? Not sure it's fool proof
  * @param <I> String class TODO understand this

--- a/src/main/java/sc/fiji/bdvpg/scijava/services/ui/SourceAndConverterPopupMenu.java
+++ b/src/main/java/sc/fiji/bdvpg/scijava/services/ui/SourceAndConverterPopupMenu.java
@@ -59,7 +59,7 @@ public class SourceAndConverterPopupMenu
 			"PopupLine",
 			getCommandName(SourcesInvisibleMakerCommand.class),
 			getCommandName(SourcesVisibleMakerCommand.class),
-			getCommandName(BrightnessAdjusterCommand.class),
+			getCommandName(InteractiveBrightnessAdjusterCommand.class),
 			getCommandName(SourceColorChangerCommand.class),
 			"PopupLine",
 			getCommandName(BasicTransformerCommand.class),

--- a/src/main/java/sc/fiji/bdvpg/scijava/services/ui/SourceAndConverterServiceUI.java
+++ b/src/main/java/sc/fiji/bdvpg/scijava/services/ui/SourceAndConverterServiceUI.java
@@ -564,13 +564,21 @@ public class SourceAndConverterServiceUI {
      */
     public Set<SourceAndConverter> getSourceAndConvertersFromChildrenOf(DefaultMutableTreeNode node) {
         Set<SourceAndConverter> sacs = new HashSet<>();
-        for (int i=0;i<node.getChildCount();i++) {
-            DefaultMutableTreeNode child = (DefaultMutableTreeNode) node.getChildAt(i);
-            if (child.getUserObject() instanceof RenamableSourceAndConverter) {
-                Object userObj = ((RenamableSourceAndConverter) (child.getUserObject())).sac;
-                sacs.add((SourceAndConverter) userObj);
-            } else {
-                sacs.addAll(getSourceAndConvertersFromChildrenOf(child));
+        if (node instanceof SourceFilterNode) {
+            sacs.addAll(((SourceFilterNode) node).currentOutputSacs);
+        } else {
+            for (int i = 0; i < node.getChildCount(); i++) {
+                DefaultMutableTreeNode child = (DefaultMutableTreeNode) node.getChildAt(i);
+                if (child instanceof SourceFilterNode) {
+                    sacs.addAll(((SourceFilterNode) child).currentOutputSacs);
+                } else {
+                    if (child.getUserObject() instanceof RenamableSourceAndConverter) {
+                        Object userObj = ((RenamableSourceAndConverter) (child.getUserObject())).sac;
+                        sacs.add((SourceAndConverter) userObj);
+                    } else {
+                        sacs.addAll(getSourceAndConvertersFromChildrenOf(child));
+                    }
+                }
             }
         }
         return sacs;

--- a/src/main/java/sc/fiji/persist/ScijavaGsonHelper.java
+++ b/src/main/java/sc/fiji/persist/ScijavaGsonHelper.java
@@ -34,7 +34,6 @@ import org.scijava.Context;
 import org.scijava.InstantiableException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import sc.fiji.bdvpg.scijava.services.ui.SourceAndConverterServiceUI;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -137,8 +136,6 @@ public class ScijavaGsonHelper {
                         e.printStackTrace();
                     }
                 });
-
-
 
         return builder.setPrettyPrinting();
     }

--- a/src/main/java/sc/fiji/persist/ScijavaGsonHelper.java
+++ b/src/main/java/sc/fiji/persist/ScijavaGsonHelper.java
@@ -138,7 +138,9 @@ public class ScijavaGsonHelper {
                     }
                 });
 
-        return builder;
+
+
+        return builder.setPrettyPrinting();
     }
 
     // Inner static class needed for type safety

--- a/src/test/src/sc/fiji/bdvpg/AffineTransformSourceDemo.java
+++ b/src/test/src/sc/fiji/bdvpg/AffineTransformSourceDemo.java
@@ -94,6 +94,7 @@ public class AffineTransformSourceDemo {
 
                 if (Math.random()>0.0) {
                     AffineTransform3D at3d = new AffineTransform3D();
+
                     at3d.rotate(2, Math.random());
                     at3d.scale(0.5 + Math.random() / 4, 0.5 + Math.random() / 4, 1);
                     at3d.translate(200 * x, 200 * y, 0);

--- a/src/test/src/sc/fiji/bdvpg/RayCastDemo.java
+++ b/src/test/src/sc/fiji/bdvpg/RayCastDemo.java
@@ -1,0 +1,29 @@
+package sc.fiji.bdvpg;
+
+import bdv.util.BdvHandle;
+import net.imagej.ImageJ;
+import sc.fiji.bdvpg.bdv.BdvHandleHelper;
+import sc.fiji.bdvpg.bdv.navigate.RayCastPositionerSliderAdder;
+import sc.fiji.bdvpg.services.SourceAndConverterServices;
+
+public class RayCastDemo {
+
+    static ImageJ ij;
+
+    public static void main(String... args) {
+        // Initializes static SourceService and Display Service
+
+        ij = new ImageJ();
+        ij.ui().showUI();
+
+        AffineTransformSourceDemo.demo(3);
+
+        BdvHandle bdvh = SourceAndConverterServices
+                .getBdvDisplayService()
+                .getActiveBdv();
+
+        BdvHandleHelper.addCenterCross(bdvh);
+
+        new RayCastPositionerSliderAdder(bdvh).run();
+    }
+}


### PR DESCRIPTION
This PR adds an actions which adds a ZSlider in a Bdv window - and a demo of it (RayCastDemo) 

Because the orientation in Bdv can be anything, the way the slider works is the following:
a 'virtual' ray is cast at the center of the bdv window and each plane which intersects this ray corresponds to a position within the slider.

All positions from all sources are finally sorted along Z.

The slider works 'directionally' : if the user moves the bdv window, the slider is updated to its new z position, if the user moves the slider, the bdv window is shifted in z according to the new position.

The slider works only for 'standard' sources ( = 3D Rai with affine transforms ), and not for warped sources.

